### PR TITLE
chore: update axios v & avoid retirejs vuln

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.0.0",
-    "axios": "0.21.1",
+    "axios": "0.27.2",
     "rollup": "^2.36.1"
   },
   "scripts": {


### PR DESCRIPTION
RetireJS spots a few vulnerabilities on axios versions < 0.21.3 :

"below": "0.21.3",
              "severity": "high",
              "identifiers": {
                "summary": "Axios is vulnerable to Inefficient Regular Expression Complexity"
                
              "severity": "medium",
              "identifiers": {
                "summary": "Axios NPM package 0.21.0 contains a Server-Side Request Forgery (SSRF) vulnerability"

              "severity": "high",
              "identifiers": {
                "summary": "Axios is vulnerable to Inefficient Regular Expression Complexity"
                
               "severity": "medium",
              "identifiers": {
                "summary": "Axios NPM package 0.21.0 contains a Server-Side Request Forgery (SSRF) vulnerability",